### PR TITLE
md -[jupytext 1.1.0]-> ipynb -[jupytext 1.3.0rc1]-> md

### DIFF
--- a/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
+++ b/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Basic description of the Python programming language, Difficulty: Easy, Category: Background
    :keywords: python, install, basics, scripts, interpreter, foundations
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Introducing the Python Programming Language
@@ -76,7 +76,7 @@ Do not use word processing programs, like Microsoft Word, to write code. They wi
 
 Now that you have a Python script, how do you get the computer to read it and follow its instructions? You will need to install a **Python interpreter** on your computer to accomplish this. This is what people mean, whether they know it or not, when they tell you to "install Python" on your computer.
 
-<!-- #region -->
+
 ## What is a Python Interpreter and What Does it Mean to "Install Python"?
 
 A Python interpreter is any computer program that is capable of doing the following:
@@ -117,7 +117,6 @@ this will instruct the Python interpreter program `python` to read your text fil
 In practice, you will be able to simply execute `python my_script.py` in any directory, and your computer will know where to look to find the `python` program. This will be set up during the installation process.
 
 It may be confusing to think that the Python language is interpreted by using a program written in another language. How, then, is that language interpreted? The answer, in the case of CPython, is that C code need not be interpreted; programs exist for Windows, Mac, and Linux that can translate C code directly into machine instructions. 
-<!-- #endregion -->
 
 <!-- #region -->
 ## Why Python?

--- a/Python/Module1_GettingStartedWithPython/Getting_Started_With_IDEs_and_Notebooks.md
+++ b/Python/Module1_GettingStartedWithPython/Getting_Started_With_IDEs_and_Notebooks.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Integrated Development Environments, Difficulty: Easy, Category: Tools
    :keywords: python, introduction, IDE, PyCharm, VSCode, Jupyter, recommendation, tools
-```
+<!-- #endraw -->
 
 # Setting Up a Development Environment
 ## What You Will Learn

--- a/Python/Module1_GettingStartedWithPython/Informal_Intro_Python.md
+++ b/Python/Module1_GettingStartedWithPython/Informal_Intro_Python.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Informal Introduction to Python, Difficulty: Easy, Category: Tutorial
    :keywords: python, installation, script, introduction, ipython, console, quick introduction
-```
+<!-- #endraw -->
 
 # An Informal Introduction to Python
 Now that you have the Anaconda distribution of Python installed on your machine, let's write some simple Python code! We are going to forego writing a full Python script for now, and instead make use of a convenient tool for doing quick code scratchwork. The IPython console was installed as a part of Anaconda; it will allow us to build incrementally off of snippets of code, instead of having to execute an entire script all at once. 

--- a/Python/Module1_GettingStartedWithPython/Installing_Python.md
+++ b/Python/Module1_GettingStartedWithPython/Installing_Python.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Installing Python with Anaconda, Difficulty: Easy, Category: Tutorial
    :keywords: python, anaconda, instructions, environments, beginner, data science, introduction
-```
+<!-- #endraw -->
 
 ## Installing Python
 
@@ -46,7 +46,7 @@ Some of the packages provided by Anaconda, like NumPy, have been [optimized](htt
 
 You will need to know how to open a terminal (cmd.exe for Windows users) on your computer, and how to navigate between directories in the terminal. If you do not know how to do this, read a 'how-to' for whatever operating system you are using.
 
-<!-- #region -->
+
 ### What did this just do to my computer?
 
 This created a directory called `Anaconda3` (or some variant of this) on your computer, which contains all of the files associated with the CPython interpreter, all of the modules in Python's standard library, the aforementioned 3rd party packages that come as part of the Anaconda distribution (e.g. NumPy, SciPy, Jupyter, iPython), and the `conda` package manager. It also contains the executable files for all of these applications. The default install location for Anaconda is:
@@ -101,4 +101,3 @@ And like that, conda environments give you all of the powers of a necromancer, a
 Conda environments have more uses than simply switching back and forth between Python 3 and 2. Many people like to make a new conda environment for every major project that they work on, so that they can freely install any dependencies that are needed for that particular project, without worrying about conflicts with their other work. You should be keen on making regular use of conda environments.
 
 It is highly recommended that you take time to read through [this tutorial on managing conda environments](https://conda.io/docs/user-guide/tasks/manage-environments.html).
-<!-- #endregion -->

--- a/Python/Module1_GettingStartedWithPython/Jupyter_Notebooks.md
+++ b/Python/Module1_GettingStartedWithPython/Jupyter_Notebooks.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Jupyter notebooks, Difficulty: Easy, Category: Tutorial
    :keywords: jupyter, notebook, kernel, basics, server, console, command line, plot, beginner, data science
-```
+<!-- #endraw -->
 
 # Jupyter Notebooks
 In recent years, the Jupyter Notebook has become a massively popular tool for doing research-oriented work in Python and other languages alike. Its emergence marked a paradigm shift in the way data science is conducted. 

--- a/Python/Module1_GettingStartedWithPython/Numerical_Work_In_Python.md
+++ b/Python/Module1_GettingStartedWithPython/Numerical_Work_In_Python.md
@@ -4,8 +4,8 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python

--- a/Python/Module1_GettingStartedWithPython/SiteFormatting.md
+++ b/Python/Module1_GettingStartedWithPython/SiteFormatting.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Overview of formatting in Python Like You Mean It, Difficulty: Easy, Category: Instructions
    :keywords: overview, formatting, background, code block, console style
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # A Quick Guide to Formatting

--- a/Python/Module2_EssentialsOfPython/Basic_Objects.md
+++ b/Python/Module2_EssentialsOfPython/Basic_Objects.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Basics of Python Objects, Difficulty: Easy, Category: Section
    :keywords: integers, booleans, floats, floating point precision, lists, strings, fundamentals
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Basic Object Types
@@ -805,7 +805,7 @@ To answer some of the following questions, you will need to peruse the documenta
 
 3\. Remove the whitespace from both ends of: `"  basket    "` 
 
-<!-- #region -->
+
 4\. Create a string that will print as (the second line begins with a tab-character):
 ```
 Hello
@@ -817,7 +817,6 @@ Hello
 6\. Only kids 13 and up are allowed to see Wayne's World. Given the variables `name` (a string) and `age` (an integer), use an f-string that will display: "NAME is old enough to watch the movie: BOOL", where NAME is to be replaced with the kid's name, and BOOL should be `True` if the kid is at least 13 years old, and `False` otherwise.
 
 </div>
-<!-- #endregion -->
 
 <!-- #region -->
 ## Lists

--- a/Python/Module2_EssentialsOfPython/ConditionalStatements.md
+++ b/Python/Module2_EssentialsOfPython/ConditionalStatements.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Conditional Statements, Difficulty: Easy, Category: Section
    :keywords: if, else, elif, inline if, switch statement, comparison operator, bool, truth, is operator
-```
+<!-- #endraw -->
 
 
 # Conditional Statements

--- a/Python/Module2_EssentialsOfPython/DataStructures.md
+++ b/Python/Module2_EssentialsOfPython/DataStructures.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Data Structures, Difficulty: Medium, Category: Section
    :keywords: Big-O, complexity, efficiency, algorithm, interview preparation, list, tuple, sequence
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Data Structures (Part I): Introduction

--- a/Python/Module2_EssentialsOfPython/DataStructures_III_Sets_and_More.md
+++ b/Python/Module2_EssentialsOfPython/DataStructures_III_Sets_and_More.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Introduction to Sets, Difficulty: Medium, Category: Section
    :keywords: set, complexity, comparison, union, intersection, membership, hashing, lookup, interview preparation
-```
+<!-- #endraw -->
 
 
 # Data Structures (Part III): Sets & the Collections Module

--- a/Python/Module2_EssentialsOfPython/DataStructures_II_Dictionaries.md
+++ b/Python/Module2_EssentialsOfPython/DataStructures_II_Dictionaries.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Introduction to Dictionaries, Difficulty: Medium, Category: Section
    :keywords: dictionary, complexity, key, value, iteration, get item, hashing, lookup, interview preparation
-```
+<!-- #endraw -->
 
 #  Data Structures (Part II): Dictionaries
 Python's dictionary allows you to store key-value pairs, and then pass the dictionary a key to quickly retrieve its corresponding value. Specifically, you construct the dictionary by specifying one-way mappings from key-objects to value-objects. **Each key must map to exactly one value**, meaning that a key must be unique. 

--- a/Python/Module2_EssentialsOfPython/ForLoops.md
+++ b/Python/Module2_EssentialsOfPython/ForLoops.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Contorl flow with for-loops and while-loops, Difficulty: Easy, Category: Section
    :keywords: for-loop, while-loop, break, control flow, basic programming
-```
+<!-- #endraw -->
 
 # For-Loops and While-Loops
 In this section, we will introduce the essential "for-loop" control flow paradigm along with the formal definition of an "iterable". The utility of these items cannot be understated. Moving forward, you will likely find use for these concepts in nearly every piece of Python code that you write!

--- a/Python/Module2_EssentialsOfPython/Functions.md
+++ b/Python/Module2_EssentialsOfPython/Functions.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Functions and Function Signatures, Difficulty: Medium, Category: Section
    :keywords: functions, *args, **kwargs, signature, default parameter, docstring, return, vowel count, syntax, basics
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Basics of Functions
@@ -68,7 +68,7 @@ In this section, we will learn about the syntax for defining and calling functio
 A Python **function** is an object that encapsulates code. *Calling* the function will execute the encapsulated code and *return* an object. A function can be defined so that it accepts *arguments*, which are objects that are to be passed to the encapsulated code.  
 </div>
 
-<!-- #region -->
+
 ## The `def` Statement
 Similar to `if`, `else`, and `for`, the `def` statement is reserved by the Python language to signify the definition of functions (and a few other things that we'll cover later). The following is the general syntax for defining a Python function:
 
@@ -88,7 +88,6 @@ def <function name>(<function signature>):
 The `return` statement is also reserved by Python. It denotes the end of a function; if reached, a `return` statement immediately concludes the execution of the function and returns the specified object. 
 
 Note that, like an if-statement and a for-loop, the `def` statment must end in a colon and the body of the function is [delimited by whitespace](https://www.pythonlikeyoumeanit.com/Module2_EssentialsOfPython/Introduction.html#Python-Uses-Whitespace-to-Delimit-Scope):
-<!-- #endregion -->
 
 <!-- #region -->
 ```python

--- a/Python/Module2_EssentialsOfPython/Generators_and_Comprehensions.md
+++ b/Python/Module2_EssentialsOfPython/Generators_and_Comprehensions.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: generators comprehensions and efficiency, Difficulty: Easy, Category: Section
    :keywords: generator, range, list comprehension, generator comprehension, nested comprehensions, inline for-loop, filtered, iterator
-```
+<!-- #endraw -->
 
 # Generators & Comprehension Expressions
 <div class="alert alert-warning">
@@ -197,7 +197,6 @@ Generator comprehensions are **not** the only method for defining generators in 
 </div>
 <!-- #endregion -->
 
-<!-- #region -->
 <div class="alert alert-info">
 
 **Reading Comprehension: Writing a Generator Comprehension**:
@@ -212,7 +211,6 @@ Note that (3, 5) is *not* in the series.
 Iterate over the generator and print its contents to verify your solution.
 
 </div>
-<!-- #endregion -->
 
 <!-- #region -->
 ### Storing generators

--- a/Python/Module2_EssentialsOfPython/Introduction.md
+++ b/Python/Module2_EssentialsOfPython/Introduction.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: introduction to control flow, Difficulty: Easy, Category: Section
    :keywords: overview, summary, if, else, function, for-loop, if, else, control flow
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Introducing Control Flow

--- a/Python/Module2_EssentialsOfPython/Iterables.md
+++ b/Python/Module2_EssentialsOfPython/Iterables.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: the basics of iterables in python, Difficulty: Medium, Category: Section
    :keywords: iterables, max, min, sum, all, any, itertools, enumerate, unpack
-```
+<!-- #endraw -->
 
 # Iterables
 Our encounter with for-loops introduced the term *iterable* - an object that can be "iterated over", such as in a for-loop.

--- a/Python/Module2_EssentialsOfPython/Itertools.md
+++ b/Python/Module2_EssentialsOfPython/Itertools.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: simple use cases of python itertools, Difficulty: Easy, Category: Tutorial
    :keywords: itertools, examples, zip, range, enumerate, chain, combinations
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Python's "Itertools"

--- a/Python/Module2_EssentialsOfPython/Problems/DifferenceFanout.md
+++ b/Python/Module2_EssentialsOfPython/Problems/DifferenceFanout.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: For-Loop Exercise, Difficulty: Easy, Category: Practice Problem
    :keywords: for loops, list, function, list comprehension, practice problem
-```
+<!-- #endraw -->
 
 
 <!-- #region -->

--- a/Python/Module2_EssentialsOfPython/Problems/EncodeAsString.md
+++ b/Python/Module2_EssentialsOfPython/Problems/EncodeAsString.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: String Encoding Exercise, Difficulty: Medium, Category: Practice Problem
    :keywords: function, string, casting, practice problem
-```
+<!-- #endraw -->
 
 # Encode as String
 Sometimes it is very important to handle different input object types differently in a function. This problem will exercise your understanding of types, control-flow, dictionaries, and more.
@@ -30,7 +30,7 @@ Sometimes it is very important to handle different input object types differentl
 - If the object is a string, keep it as is.
 - If the object is of any other type, return `'<OTHER>'`.
 
-<!-- #region -->
+
 ``` Python
 # example behavior
 >>> s = concat_to_str([12,-14.23,"hello", True,
@@ -40,7 +40,6 @@ Sometimes it is very important to handle different input object types differentl
 ```
 
 **Tips**: check out the `isinstance` function introduced [here](https://www.pythonlikeyoumeanit.com/Module2_EssentialsOfPython/Basic_Objects.html) for handling different types. Also, consider creating a helper function for the conversion from integer to our special-format string, since we have to do it twice. It's always good to extrapolate repeated tasks into functions. You'll also need to hard-code the conversion from each digit to its English spell-out. 
-<!-- #endregion -->
 
 <!-- #region -->
 ## Solution

--- a/Python/Module2_EssentialsOfPython/Problems/MarginPercentage.md
+++ b/Python/Module2_EssentialsOfPython/Problems/MarginPercentage.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Within Margin Exercise, Difficulty: Medium, Category: Practice Problem
    :keywords: function, control flow, comparisons, practice problem
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Within Margin Percentage

--- a/Python/Module2_EssentialsOfPython/Problems/MergeMaxDicts.md
+++ b/Python/Module2_EssentialsOfPython/Problems/MergeMaxDicts.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Dictionary Merge Exercise, Difficulty: Easy, Category: Practice Problem
    :keywords: dictionary, merge, practice problem
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Merging Two Dictionaries

--- a/Python/Module2_EssentialsOfPython/Problems/Palindrome.md
+++ b/Python/Module2_EssentialsOfPython/Problems/Palindrome.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Palindrome Exercise, Difficulty: Easy, Category: Practice Problem
    :keywords: string, palindrome, practice problem
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Is Palindrome

--- a/Python/Module2_EssentialsOfPython/Scope.md
+++ b/Python/Module2_EssentialsOfPython/Scope.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: variable score and namespaces in python, Difficulty: Medium, Category: Section
    :keywords: variable, namespace, function, scope, shadowing
-```
+<!-- #endraw -->
 
 # Scope
 

--- a/Python/Module2_EssentialsOfPython/SequenceTypes.md
+++ b/Python/Module2_EssentialsOfPython/SequenceTypes.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: understanding python sequences, Difficulty: Easy, Category: Section
    :keywords: list, tuple, string, slice, index, negative index, get item, pop, append, examples
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Sequence Types

--- a/Python/Module2_EssentialsOfPython/Variables_and_Assignment.md
+++ b/Python/Module2_EssentialsOfPython/Variables_and_Assignment.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: variable naming and assignment, Difficulty: Medium, Category: Section
    :keywords: variable naming, valid names, mutable, immutable, reference, pointer
-```
+<!-- #endraw -->
 
 # Variables & Assignment
 

--- a/Python/Module3_IntroducingNumpy/AccessingDataAlongMultipleDimensions.md
+++ b/Python/Module3_IntroducingNumpy/AccessingDataAlongMultipleDimensions.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Indexing into multi-dimensional numpy arrays, Difficulty: Easy, Category: Section
    :keywords: numpy array, multidimensional, index, slice, negative index, rows, columns
-```
+<!-- #endraw -->
 
 <!-- #region -->
 #  Accessing Data Along Multiple Dimensions in an Array

--- a/Python/Module3_IntroducingNumpy/AdvancedIndexing.md
+++ b/Python/Module3_IntroducingNumpy/AdvancedIndexing.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Advanced indexing with numpy arrays, Difficulty: Hard, Category: Section
    :keywords: numpy array, integer array indexing, boolean array indexing, copy indexing, advanced
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Advanced Indexing

--- a/Python/Module3_IntroducingNumpy/ArrayTraversal.md
+++ b/Python/Module3_IntroducingNumpy/ArrayTraversal.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Numpy array traversal ordering, Difficulty: Medium, Category: Section
    :keywords: row-major order, c order, column-major order, f order, traversal, array iteration
-```
+<!-- #endraw -->
 
 # Iterating Over Arrays & Array-Traversal Order
 In this section, you will learn:

--- a/Python/Module3_IntroducingNumpy/BasicArrayAttributes.md
+++ b/Python/Module3_IntroducingNumpy/BasicArrayAttributes.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Numpy array attributes, Difficulty: Easy, Category: Section
    :keywords: ndim, shape, size, itemsize, dtype, examples
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Basic Array Attributes

--- a/Python/Module3_IntroducingNumpy/BasicIndexing.md
+++ b/Python/Module3_IntroducingNumpy/BasicIndexing.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Numpy array basic indexing, Difficulty: Medium, Category: Section
    :keywords: basic index, slice, no copy index, multidimensional array, nd array, view, reverse, axis
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Introducing Basic and Advanced Indexing

--- a/Python/Module3_IntroducingNumpy/Broadcasting.md
+++ b/Python/Module3_IntroducingNumpy/Broadcasting.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Numpy array broadcasting, Difficulty: Medium, Category: Section
    :keywords: broadcasting, vectorization, rules, mismatched shapes, distances
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Array Broadcasting
@@ -138,7 +138,7 @@ The two arrays are broadcast-compatible if either of these conditions are satisf
 
 </div>
 
-<!-- #region -->
+
 Note that it is okay to have one array with a higher-dimensionality and thus to have "dangling" leading dimensions. Any size-1 dimension or "missing" dimension will be filled-in by broadcasting the content of that array.
 
 Considering the example from the preceding subsection, let's see that the shape-(4,3) and shape-(3,) arrays satisfy these rules for broadcast-compatibility:
@@ -180,7 +180,6 @@ result-shape: INCOMPATIBLE
 result-shape: 2 x 1
 ```
 
-<!-- #endregion -->
 
 <!-- #region -->
 NumPy provides the function [broadcast_to](https://docs.scipy.org/doc/numpy/reference/generated/numpy.broadcast_to.html#numpy.broadcast_to), which can be used to broadcast an array to a specified shape. This can help us build our intuition for broadcasting. Let's broadcast a shape-(3,4) array to a shape-(2,3,4) array:

--- a/Python/Module3_IntroducingNumpy/FunctionsForCreatingNumpyArrays.md
+++ b/Python/Module3_IntroducingNumpy/FunctionsForCreatingNumpyArrays.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Creating numpy arrays, Difficulty: Easy, Category: Section
    :keywords: create array, ndarray, ones, random, zeros, empty, examples, arange, linspace, reshape, hstack, vstack
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Functions for Creating NumPy Arrays 

--- a/Python/Module3_IntroducingNumpy/IntroducingTheNDarray.md
+++ b/Python/Module3_IntroducingNumpy/IntroducingTheNDarray.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Introduction to numpy arrays, Difficulty: Easy, Category: Section
    :keywords: numpy array, ndarray, introduction, overview
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Introducing the ND-array

--- a/Python/Module3_IntroducingNumpy/Problems/ComputeAccuracy.md
+++ b/Python/Module3_IntroducingNumpy/Problems/ComputeAccuracy.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Measuring classification accuracy, Difficulty: Easy, Category: Practice Problem
    :keywords: numpy, vectorization, practice, machine learning, classifier
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Measuring the Accuracy of a Classification Model

--- a/Python/Module3_IntroducingNumpy/VectorizedOperations.md
+++ b/Python/Module3_IntroducingNumpy/VectorizedOperations.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Vectorized operations with numpy arrays, Difficulty: Easy, Category: Section
    :keywords: vectorize, optimized, calculation, numpy, fast, C routine, MKL, sum, linear algebra, optimized
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # "Vectorized" Operations: Optimized Computations on NumPy Arrays

--- a/Python/Module4_OOP/Applications_of_OOP.md
+++ b/Python/Module4_OOP/Applications_of_OOP.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Applications of object-oriented programming, Difficulty: Medium, Category: Section
    :keywords: summary, tutorial, python shopping list, object oriented, method, attribute
-```
+<!-- #endraw -->
 
 # Applications of Object Oriented Programming
 

--- a/Python/Module4_OOP/Brief_Review.md
+++ b/Python/Module4_OOP/Brief_Review.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Brief review of object oriented programming, Difficulty: Easy, Category: Tutorial
    :keywords: class definition, simple, examples, overview, init, initialize, type, object
-```
+<!-- #endraw -->
 
 <!-- #region -->
 ## A Brief Summary of Terms and Concepts

--- a/Python/Module4_OOP/ClassDefinition.md
+++ b/Python/Module4_OOP/ClassDefinition.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: The rules for defining classes in python, Difficulty: Easy, Category: Section
    :keywords: class definition, scope, class object, attribute, method
-```
+<!-- #endraw -->
 
 
 <!-- #region -->

--- a/Python/Module4_OOP/ClassInstances.md
+++ b/Python/Module4_OOP/ClassInstances.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Class instances versus objects, Difficulty: Medium, Category: Section
    :keywords: instance, class creation, init, self, isinstance
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Instances of a Class

--- a/Python/Module4_OOP/Inheritance.md
+++ b/Python/Module4_OOP/Inheritance.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Class inheritance, Difficulty: Easy, Category: Section
    :keywords: inherit, object oriented, overwrite, sub class, issubclass
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Inheritance

--- a/Python/Module4_OOP/Introduction_to_OOP.md
+++ b/Python/Module4_OOP/Introduction_to_OOP.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Introducing object oriented programming in python, Difficulty: Easy, Category: Section
    :keywords: class, type, creation, definition, intro, overview, basics, meaning
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Introduction to Object Oriented Programming

--- a/Python/Module4_OOP/Methods.md
+++ b/Python/Module4_OOP/Methods.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: The different kinds of class methods, Difficulty: Medium, Category: Section
    :keywords: instance, class method, static method, property, abstract method, class funtion
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Methods

--- a/Python/Module4_OOP/ObjectOrientedProgramming.md
+++ b/Python/Module4_OOP/ObjectOrientedProgramming.md
@@ -4,8 +4,8 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
@@ -328,7 +328,6 @@ class Rational:
         self.denom = denom // factor
 <!-- #endregion -->
 
-<!-- #region -->
     def __add__(self, other):
         ''' Overload the `+` operator 
         
@@ -424,7 +423,6 @@ class Rational:
         '''
         return 'Rational({}, {})'.format(self.num, self.denom)
 ```
-<!-- #endregion -->
 
 ```python
 

--- a/Python/Module4_OOP/Special_Methods.md
+++ b/Python/Module4_OOP/Special_Methods.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Controlling behavior with special methods, Difficulty: Medium, Category: Section
    :keywords: dunder method, special method, operator overload, repr, getitem, custom syntax, __init__
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Special Methods

--- a/Python/Module5_OddsAndEnds/Modules_and_Packages.md
+++ b/Python/Module5_OddsAndEnds/Modules_and_Packages.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Understanding imports modules and packages, Difficulty: Easy, Category: Section
    :keywords: custom package, module, script, import, setup, pip, conda, relative import, absolute import 
-```
+<!-- #endraw -->
 
 <!-- #region -->
 # Import: Modules and Packages
@@ -404,7 +404,6 @@ In lieu of printing out your `PYTHONPATH`, you can look up the location of your 
 It must be mentioned that we are sweeping some details under the rug here. Installing NumPy does not merely entail copying its various modules and packages wholesale into site-packages. That being said, we will not dive any deeper into the technical details of package installation beyond understanding where packages are installed and thus where our Python interpreter looks to import them.
 <!-- #endregion -->
 
-<!-- #region -->
 ### Installing Your Own Python Package
 
 Suppose that we are happy with the work we have done on our `face_detector` project. We will want to install this package - placing it in our site-packages directory so that we can import it irrespective of our Python interpreter's working directory. Here we will construct a basic setup script that will allow us to accomplish this. 
@@ -425,7 +424,6 @@ Carrying on, we will want to create a setup-script, `setup.py`, *in the same dir
         |-- calibration.py
         |-- config.py
 ```
-<!-- #endregion -->
 
 <!-- #region -->
 The bare bones build script for preparing your package for installation, `setup.py`, is as follows: 
@@ -444,7 +442,6 @@ setuptools.setup(
 
 <!-- #endregion -->
 
-<!-- #region -->
 If you read through the additional materials linked above, you will see that there are many more fields of optional information that can be provided in this setup script, such as the author name, any installation requirements that the package has, and more.
 
 Armed with this script, we are ready to install our package locally on our machine! In your terminal, navigate to the directory containing this setup script and your package that it being installed. Run
@@ -464,9 +461,8 @@ One final but important detail. The installed version of your package will no lo
 ```shell
 python setup.py develop
 ```
-<!-- #endregion -->
 
-<!-- #region -->
+
 ## pip and conda: Package Managers
 
 Python packages can be shared worldwide. There are two widely-used Python package managers, `pip` and `conda`. `pip` downloads and installs packages from [The Python Package Index (PyPI)](https://pypi.org/), whereas `conda` downloads and installs packages from the Anaconda Cloud. Both `conda` and `pip` are installed as part of the [Anaconda distribution](http://www.pythonlikeyoumeanit.com/Module1_GettingStartedWithPython/Installing_Python.html#Installing-Anaconda). 
@@ -488,7 +484,7 @@ Both managers will install packages to your site-packages directory.
 There are substantial benefits for using `conda` rather than `pip` to install packages. First and foremost, `conda` has a powerful "environment solver", which tracks the inter-dependencies of Python packages. Thus it will attempt to install, upgrade, and downgrade packages as needed to accommodate your installations. Additionally, the default list of packages available via `conda` are curated and maintained by Continuum Analytics, the creators of Anaconda. To elucidate one of the benefits of this, installing NumPy via `pip` will deliver the vanilla version of NumPy to you; `conda` will install an [mkl-optimized version of NumPy](https://software.intel.com/en-us/articles/numpyscipy-with-intel-mkl), which can execute routines substantially faster. Finally, `conda` also serves as [an environment manager](https://conda.io/docs/user-guide/tasks/manage-environments.html), which allows you to maintain multiple, non-conflicting environments that can house different configurations of installed Python packages and even different versions of Python itself.
 
 That being said, there are some benefits to using `pip`. PyPi is accessible and easy to upload packages to; this is likely the easiest means for distributing a Python package worldwide. As such, `pip` provides access to a wider range of Python packages. That being said, `conda` can also be directed to install packages from custom channels - providing access to packages outside of the curated Anaconda distribution. This has become a popular method of installation for machine learning libraries like PyTorch and TensorFlow.
-<!-- #endregion -->
+
 
 You are free to install some packages using `conda` and others with `pip`. Just take care not to accidentally install the same package with both - this can lead to a real mess.
 

--- a/Python/Module5_OddsAndEnds/WorkingWithFiles.md
+++ b/Python/Module5_OddsAndEnds/WorkingWithFiles.md
@@ -4,19 +4,19 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
 ---
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Working with aths and files, Difficulty: Medium, Category: Section
    :keywords: open file, read file, pathlib, join directory, context manager, close file, rb, binary file, utf-8, encoding, pickle, numpy, load, archive, npy, npz, pkl, glob, read lines, write, save
-```
+<!-- #endraw -->
 
 # Working with Files
 This section will discuss the best practices for writing Python code that involves reading from and writing to files. We will learn about the built-in `pathlib.Path` object, which will help to ensure that the code that we write is portable across operating systems (OS) (e.g. Windows, MacOS, Linux). We will also be introduced to a *context manager*, `open`, which will permit us to read-from and write-to a file safely; by "safely" we mean that we will be assured that any file that we open will eventually be closed properly, so that it will not be corrupted even in the event that our code hits an error. Next, we will learn how to "glob" for files, meaning that we will learn to search for and list files whose names match specific patterns. Lastly, we will briefly encounter the `pickle` module which allows us to save (or "pickle") and load Python objects to and from your computer's file system.  
@@ -249,7 +249,6 @@ with open("a_poem.txt", mode="r") as my_open_file:
 ```
 <!-- #endregion -->
 
-<!-- #region -->
 ## Globbing for Files
 
 There are many cases in which we may want to construct a list of files to iterate over. For example, if we have several data files, it would be useful to create a file list which we can iterate through and process in sequence. One way to do this would be to manually construct such a list of files:
@@ -317,9 +316,8 @@ Write a glob pattern for each of the following prompts
 - Glob all file that starts with the letter 'q', contains a 'w', and ends with a '.npy' extension
 
 </div>
-<!-- #endregion -->
 
-<!-- #region -->
+
 The `*` wildcard is not the only pattern available to us. Sometimes it can be useful to match certain subsets of characters. For example, we may only want to match file names that start with a number. With the `*` wildcard alone, that's not possible. Luckily for us, these common use-cases are also taken care of.
 
 To match a subset of characters, we can use square brackets: `[abc]*` will match anything that starts with 'a', 'b', or 'c' and nothing else. We can also use a '-' inside our brackets to glob groups of characters. For example:
@@ -345,7 +343,6 @@ Write a glob pattern for each of the following prompts
 - All txt files that have the letters 'q' or 'z' in them
 
 </div>
-<!-- #endregion -->
 
 <!-- #region -->
 ## Saving & Loading Python Objects: pickle

--- a/Python/Module5_OddsAndEnds/Writing_Good_Code.md
+++ b/Python/Module5_OddsAndEnds/Writing_Good_Code.md
@@ -4,8 +4,8 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc0
+      format_version: '1.2'
+      jupytext_version: 1.3.0rc1
   kernelspec:
     display_name: Python 3
     language: python
@@ -13,11 +13,11 @@ jupyter:
 ---
 
 
-```raw_mimetype="text/restructuredtext"
+<!-- #raw raw_mimetype="text/restructuredtext" -->
 .. meta::
    :description: Topic: Writing good code, Difficulty: Easy, Category: Section
    :keywords: pep8, code style, lint, format, best practices, type hint, documentation, numpydoc, sphinx, typing, annotation, whitespace
-```
+<!-- #endraw -->
 
 # Writing Good Code
 
@@ -725,7 +725,7 @@ There is great wisdom in placing such a high value on documentation. In this sec
 
 PLYMI uses Numpy-style docstrings throughout most of the text (except for when we are trying to keep the functions brief). This is ultimately just a choice of style/aesthetics. Ultimately, the critical takeaway here is to **pick a documentation style, learn it, and stick to it faithfully**. Once again, it is hard to overstate how important it is to anchor your code with clear and consistent documentation. It will aid you in your code-writing process, it will enable users to adopt and perhaps contribute to your code, and it will ensure longevity for your hard work.
 
-<!-- #region -->
+
 ### The NumPy Documentation Style
 
 The NumPy documentation style is specified in full [here](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard). It is strongly recommended that you read through it in full. There are details in the specification that we will pass over here for the sake of simplicity and to avoid rewriting their specification. We will focus on the guidelines for documenting functions, but note that they specify rules for documenting [classes](https://www.pythonlikeyoumeanit.com/module_4.html) and [modules](https://www.pythonlikeyoumeanit.com/Module5_OddsAndEnds/Modules_and_Packages.html#Modules).
@@ -743,7 +743,6 @@ A docstring should at least consist of:
  - An extended summary of the function, which provides a more verbose description of things.
  - A `Parameters` section, which details the types of the input parameters along with descriptions of them. (This section is not necessary if your function is parameterless).
  - A `Returns` section (or `Yields` for a generator), which details the object that is returned by the function. (This is not necessary if your function always returns `None`).
-<!-- #endregion -->
 
 <!-- #region -->
 There are additional, optional sections that can be used to improve your documentation: 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Once this environment is created activate it. You may need to manually install a
 
 ```shell
 pip install sphinx-rtd-theme==0.4.3
-pip install jupytext==1.1.1
+pip install jupytext-1.3.0rc1
 ```
 
 Using this environment, you should now be able to run sphinx to build the html for this site from the source-code. To do this, navigate to the directory named Python in this repository, and then run:

--- a/plymi.yml
+++ b/plymi.yml
@@ -111,7 +111,7 @@ dependencies:
     - docutils==0.14
     - idna==2.8
     - imagesize==1.1.0
-    - jupytext==1.1.1
+    - jupytext-1.3.0rc1
     - mock==2.0.0
     - numpydoc==0.9.1
     - pbr==5.2.0


### PR DESCRIPTION
This PR updates the `jupytext` version for encoding all of the jupytext-markdown documents.

@alexding123 you will want to upgrade your markdown files as well to keep in sync. I have written some tooling to do so. This repo now has an installable python package called `plymi`. Once you install it, you can simply upgrade to `jupytext==1.3.0rc2` and run:

```python
import plymi
from pathlib import Path
root = Path("./Learning_Python/").absolute()
plymi.convert_all_markdown_to_markdown(root)
```

Assuming that you are using the same directory / notebook names as me, this will upgrade all of your notebooks.