### PR TITLE
Add section on Python versions

### DIFF
--- a/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
+++ b/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
@@ -170,7 +170,10 @@ Python 3.7 and 3.8 are great examples of this - any code that works in Python 3.
 All code within the same minor release will run on all other patches within that minor release - all Python 3.7.8 code is compatible with a Python 3.7.1 interpreter, and vice versa. 
 Patches are released fairly often, and their changes only occur 'under the hood'.
 
-We will be using Python 3 in this course. Python 3.7.8 is compatible with most packages while Python 3.8.4 is not yet, so if you need to use a variety of packages it is safer to stick with Python 3.7.8. Otherwise, you will have no problems switching to Python 3.8.4.
+We will be using Python 3 in this course. 
+Python 3.7.8 is compatible with most packages while Python 3.8.4 is not yet, so if you need to use a variety of packages it is safer to stick with Python 3.7.8. 
+Otherwise, you will have no problems switching to Python 3.8.4.
+Luckily, Anaconda manages compatibility for you, so you shouldn't have to worry too much about which version of Python you use as long as you occasionally check for updates.
 
 <!-- #endregion -->
 

--- a/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
+++ b/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
@@ -169,10 +169,6 @@ Patches are released fairly often, and their changes only occur 'under the hood'
 In simpler terms, major releases are neither backward nor forward compatible.
 Minor releases are forward compatible but not necessarily fully backward compatible, and patches are both forward and backward compatible.
 
-Unfortunately, it takes time for packages to support the newest versions of Python.
-As a result, it can sometimes be necessary to use older versions to maintain compatibility.
-Anaconda will manage package compatability for you most of the time, but be careful not to mix incompatible libraries.
-
 <!-- #endregion -->
 
 ## Summary

--- a/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
+++ b/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
@@ -157,7 +157,8 @@ The three numbers denote major releases, minor releases, and patches.
 
 The first number denotes major releases to the language. 
 When a major release comes out, it means that older code will not necessarily work with the new release, and vice versa. 
-The most current major release is Python 3, but Python 2 is still occasionally used. 
+The most current major release is Python 3; Python 2 is no longer supported by any bug or security fixes.
+All releases in the near future will be improvements to Python 3, and thus they will come in the form of minor releases and patches.
 
 The second number denotes a minor release. 
 When a minor release comes out, older code will run in the new interpreter, but new code will not necessarily be compatible with older versions.

--- a/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
+++ b/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
@@ -149,8 +149,6 @@ We will be relying heavily on Python and a library for doing optimized numerical
 
 New versions of Python come out periodically, bringing new features and fixes. 
 It's important to keep Python updated in order to make sure that you have access to the latest additions to the language.
-Unfortunately, it takes time for packages to support the newest versions of Python.
-As a result, it can sometimes be necessary to use older versions to maintain compatibility.
 
 All Python version numbers use the `A.B.C` format, in accordance with [semantic versioning](https://semver.org/). 
 The three numbers denote major releases, minor releases, and patches.
@@ -170,6 +168,10 @@ Patches are released fairly often, and their changes only occur 'under the hood'
 
 In simpler terms, major releases are neither backward nor forward compatible.
 Minor releases are forward compatible but not necessarily fully backward compatible, and patches are both forward and backward compatible.
+
+Unfortunately, it takes time for packages to support the newest versions of Python.
+As a result, it can sometimes be necessary to use older versions to maintain compatibility.
+Anaconda will manage package compatability for you most of the time, but be careful not to mix incompatible libraries.
 
 <!-- #endregion -->
 

--- a/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
+++ b/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
@@ -152,31 +152,23 @@ It's important to keep Python updated in order to make sure that you have access
 Unfortunately, it takes time for packages to support the newest versions of Python.
 As a result, it can sometimes be necessary to use older versions to maintain compatibility.
 
-All Python version numbers use the A.B.C format, in accordance with [semantic versioning](https://semver.org/). 
+All Python version numbers use the `A.B.C` format, in accordance with [semantic versioning](https://semver.org/). 
 The three numbers denote major releases, minor releases, and patches.
 
-- The first number denotes major releases to the language. 
+The first number denotes major releases to the language. 
 When a major release comes out, it means that older code will not necessarily work with the new release, and vice versa. 
 The most current major release is Python 3, but Python 2 is still occasionally used. 
-Running Python 2 code in a Python 3 interpreter can yield errors, as can running Python 3 code in a Python 2 interpreter. 
-Python 2 has been deprecated and should not be used, but the transition to Python 3 has been slow.
-When reading code from the Internet, always check to make sure it uses Python 3.
 
-- The second number denotes a minor release. 
+The second number denotes a minor release. 
 When a minor release comes out, older code will run in the new interpreter, but new code will not necessarily be compatible with older versions.
 For example, any code that works in Python 3.7 will run in Python 3.8, but because Python 3.8 added new syntax, code from Python 3.8 will not necessarily run in a Python 3.7 interpreter.
 
-- The third and final number denotes a patch, which generally means bug fixes and performance improvements. 
+The third and final number denotes a patch, which generally means bug fixes and performance improvements. 
 All code within the same minor release will run on all other patches within that minor release - for example, all Python 3.7.8 code is compatible with a Python 3.7.1 interpreter, and vice versa. 
 Patches are released fairly often, and their changes only occur 'under the hood'.
 
 In simpler terms, major releases are neither backward nor forward compatible.
-Minor releases are backward compatible but not forward compatible, and patches are both forward and backward compatible.
-
-We will be using Python 3 in this course. 
-If you use a wide variety of packages, you may need to use an older minor release of Python 3 to ensure compatibility.
-Otherwise, you should use whatever [the most current version of Python](https://www.python.org/downloads/) is.
-Luckily, Anaconda manages compatibility for you, so you shouldn't have to worry too much about which version of Python you use as long as you occasionally check for updates.
+Minor releases are forward compatible but not necessarily fully backward compatible, and patches are both forward and backward compatible.
 
 <!-- #endregion -->
 

--- a/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
+++ b/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
@@ -144,6 +144,36 @@ As such, Python is a language that is conducive to rapidly prototyping and testi
 We will be relying heavily on Python and a library for doing optimized numerical computations, called NumPy, throughout this course.
 <!-- #endregion -->
 
+<!-- #region -->
+## Keeping Up To Date
+
+New versions of Python come out periodically, bringing new features and fixes. 
+The most recent version of Python is Python 3.8.4.
+Unfortunately, it takes time for packages to support new versions of Python.
+As a result, many packages don't support Python 3.8, and will require you to install Python 3.7 or, in some cases, 3.6.
+
+All Python versions numbers use the A.B.C format. 
+The three numbers denote major releases, minor releases, and patches.
+
+- The first number denotes major releases to the language. 
+The most current major release is Python 3, but Python 2 is still in use. 
+When a major release comes out, it means that older code will not necessarily work with the new release. 
+Running Python 2 code in a Python 3 interpreter can yield errors, as can running Python 3 code in a Python 2 interpreter. 
+Python 2 is no longer supported, but the transition to Python 3 has been slow.
+When reading code from the Internet, always check to make sure it uses Python 3.
+
+- The second number denotes a minor release. 
+When a minor release comes out, older code will run in the new interpreter, but new code will not necessarily be compatible with older versions. 
+Python 3.7 and 3.8 are great examples of this - any code that works in Python 3.7 will run in Python 3.8, but new syntax has been added that will not work in Python 3.7.
+
+- The third and final number denotes a patch, which generally means bug fixes and performance improvements. 
+All code within the same minor release will run on all other patches within that minor release - all Python 3.7.8 code is compatible with a Python 3.7.1 interpreter, and vice versa. 
+Patches are released fairly often, and their changes only occur 'under the hood'.
+
+We will be using Python 3 in this course. Python 3.7.8 is compatible with most packages while Python 3.8.4 is not yet, so if you need to use a variety of packages it is safer to stick with Python 3.7.8. Otherwise, you will have no problems switching to Python 3.8.4.
+
+<!-- #endregion -->
+
 ## Summary
 
 - Python is a programming language - it provides us with a simple set of grammatical rules that allow us to write human-readable text, which can be translated unambiguously to instruct a computer to perform tasks.

--- a/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
+++ b/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
@@ -156,8 +156,8 @@ All Python version numbers use the A.B.C format, in accordance with [semantic ve
 The three numbers denote major releases, minor releases, and patches.
 
 - The first number denotes major releases to the language. 
-When a major release comes out, it means that older code will not necessarily work with the new release. 
-The most current major release is Python 3, but Python 2 is still in use. 
+When a major release comes out, it means that older code will not necessarily work with the new release, and vice versa. 
+The most current major release is Python 3, but Python 2 is still occasionally used. 
 Running Python 2 code in a Python 3 interpreter can yield errors, as can running Python 3 code in a Python 2 interpreter. 
 Python 2 has been deprecated and should not be used, but the transition to Python 3 has been slow.
 When reading code from the Internet, always check to make sure it uses Python 3.
@@ -174,7 +174,7 @@ In simpler terms, major releases are neither backward nor forward compatible.
 Minor releases are backward compatible but not forward compatible, and patches are both forward and backward compatible.
 
 We will be using Python 3 in this course. 
-If you use a wide variety of packages, you may need to use an older minor release to ensure compatibility.
+If you use a wide variety of packages, you may need to use an older minor release of Python 3 to ensure compatibility.
 Otherwise, you should use whatever [the most current version of Python](https://www.python.org/downloads/) is.
 Luckily, Anaconda manages compatibility for you, so you shouldn't have to worry too much about which version of Python you use as long as you occasionally check for updates.
 

--- a/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
+++ b/Python/Module1_GettingStartedWithPython/GettingStartedWithPython.md
@@ -148,31 +148,34 @@ We will be relying heavily on Python and a library for doing optimized numerical
 ## Keeping Up To Date
 
 New versions of Python come out periodically, bringing new features and fixes. 
-The most recent version of Python is Python 3.8.4.
-Unfortunately, it takes time for packages to support new versions of Python.
-As a result, many packages don't support Python 3.8, and will require you to install Python 3.7 or, in some cases, 3.6.
+It's important to keep Python updated in order to make sure that you have access to the latest additions to the language.
+Unfortunately, it takes time for packages to support the newest versions of Python.
+As a result, it can sometimes be necessary to use older versions to maintain compatibility.
 
-All Python versions numbers use the A.B.C format. 
+All Python version numbers use the A.B.C format, in accordance with [semantic versioning](https://semver.org/). 
 The three numbers denote major releases, minor releases, and patches.
 
 - The first number denotes major releases to the language. 
-The most current major release is Python 3, but Python 2 is still in use. 
 When a major release comes out, it means that older code will not necessarily work with the new release. 
+The most current major release is Python 3, but Python 2 is still in use. 
 Running Python 2 code in a Python 3 interpreter can yield errors, as can running Python 3 code in a Python 2 interpreter. 
-Python 2 is no longer supported, but the transition to Python 3 has been slow.
+Python 2 has been deprecated and should not be used, but the transition to Python 3 has been slow.
 When reading code from the Internet, always check to make sure it uses Python 3.
 
 - The second number denotes a minor release. 
-When a minor release comes out, older code will run in the new interpreter, but new code will not necessarily be compatible with older versions. 
-Python 3.7 and 3.8 are great examples of this - any code that works in Python 3.7 will run in Python 3.8, but new syntax has been added that will not work in Python 3.7.
+When a minor release comes out, older code will run in the new interpreter, but new code will not necessarily be compatible with older versions.
+For example, any code that works in Python 3.7 will run in Python 3.8, but because Python 3.8 added new syntax, code from Python 3.8 will not necessarily run in a Python 3.7 interpreter.
 
 - The third and final number denotes a patch, which generally means bug fixes and performance improvements. 
-All code within the same minor release will run on all other patches within that minor release - all Python 3.7.8 code is compatible with a Python 3.7.1 interpreter, and vice versa. 
+All code within the same minor release will run on all other patches within that minor release - for example, all Python 3.7.8 code is compatible with a Python 3.7.1 interpreter, and vice versa. 
 Patches are released fairly often, and their changes only occur 'under the hood'.
 
+In simpler terms, major releases are neither backward nor forward compatible.
+Minor releases are backward compatible but not forward compatible, and patches are both forward and backward compatible.
+
 We will be using Python 3 in this course. 
-Python 3.7.8 is compatible with most packages while Python 3.8.4 is not yet, so if you need to use a variety of packages it is safer to stick with Python 3.7.8. 
-Otherwise, you will have no problems switching to Python 3.8.4.
+If you use a wide variety of packages, you may need to use an older minor release to ensure compatibility.
+Otherwise, you should use whatever [the most current version of Python](https://www.python.org/downloads/) is.
 Luckily, Anaconda manages compatibility for you, so you shouldn't have to worry too much about which version of Python you use as long as you occasionally check for updates.
 
 <!-- #endregion -->

--- a/Python/index.rst
+++ b/Python/index.rst
@@ -44,7 +44,7 @@ The following people made significant contributions to PLYMI, adding problems wi
 - AJ Federici (GitHub:`@Federici <https://github.com/AFederici>`_)
 - Annabelle Lew (GitHub:`@AnnabelleLew <https://github.com/AnnabelleLew>`_)
 - Petar Griggs (GitHub:`@petarmhg <https://github.com/petarmhg>`_)
-- Sam Carpenter (GitHub:`@HardBoiled800 <https://github.com/HardBoiled800>`_)
+- Sam Carpenter (GitHub:`@samaocarpenter <https://github.com/samaocarpenter>`_)
 - Patrick O'Shea (GitHub:`@ArtichokeSap <https://github.com/ArtichokeSap>`_)
 
 

--- a/Python/intro.rst
+++ b/Python/intro.rst
@@ -44,7 +44,7 @@ The following people made significant contributions to PLYMI, adding problems wi
 - AJ Federici (GitHub:`@Federici <https://github.com/AFederici>`_)
 - Annabelle Lew (GitHub:`@AnnabelleLew <https://github.com/AnnabelleLew>`_)
 - Petar Griggs (GitHub:`@petarmhg <https://github.com/petarmhg>`_)
-- Sam Carpenter (GitHub:`@HardBoiled800 <https://github.com/HardBoiled800>`_)
+- Sam Carpenter (GitHub:`@samaocarpenter <https://github.com/samaocarpenter>`_)
 - Patrick O'Shea (GitHub:`@ArtichokeSap <https://github.com/ArtichokeSap>`_)
 
 


### PR DESCRIPTION
This adds a short section on Python versions, how to interpret version numbers, and what updates mean.

It also corrects my GitHub link in the intro page, since I changed my URL a couple months ago